### PR TITLE
Changes in React table sorting and addition of symbols in sub-table headers 

### DIFF
--- a/src/component/panels/IntegralTablePanel.jsx
+++ b/src/component/panels/IntegralTablePanel.jsx
@@ -34,18 +34,21 @@ const IntegralTablePanel = () => {
     {
       Header: 'From',
       accessor: 'from',
+      sortType: 'basic',
       resizable: true,
       Cell: ({ row }) => row.original.from.toFixed(2),
     },
     {
       Header: 'To',
       accessor: 'to',
+      sortType: 'basic',
       resizable: true,
       Cell: ({ row }) => row.original.to.toFixed(2),
     },
     {
       Header: 'Integral',
       accessor: 'value',
+      sortType: 'basic',
       resizable: true,
       Cell: ({ row }) => row.original.value.toFixed(2),
     },

--- a/src/component/panels/PeaksTablePanel.jsx
+++ b/src/component/panels/PeaksTablePanel.jsx
@@ -35,14 +35,17 @@ const PeaksTablePanel = () => {
     {
       Header: 'peak index',
       accessor: 'xIndex',
+      sortType: 'basic',
     },
     {
       Header: 'δ (ppm)',
       accessor: 'value',
+      sortType: 'basic',
     },
     {
       Header: 'Intensity ',
       accessor: 'yValue',
+      sortType: 'basic',
     },
     {
       Header: '',

--- a/src/component/panels/RangesTablePanel.jsx
+++ b/src/component/panels/RangesTablePanel.jsx
@@ -65,16 +65,19 @@ const RangesTablePanel = () => {
     {
       Header: 'From',
       accessor: 'from',
+      sortType: 'basic',
       Cell: ({ row }) => row.original.from.toFixed(2),
     },
     {
       Header: 'To',
       accessor: 'to',
+      sortType: 'basic',
       Cell: ({ row }) => row.original.to.toFixed(2),
     },
     {
       Header: 'Integral',
       accessor: 'integral',
+      sortType: 'basic',
       Cell: ({ row }) => row.original.integral.toFixed(1),
     },
     {
@@ -109,8 +112,9 @@ const RangesTablePanel = () => {
           accessor: 'multiplicity',
         },
         {
-          Header: 'Delta',
+          Header: '\u0394 (ppm)',
           accessor: 'delta',
+          sortType: 'basic',
           Cell: ({ row }) => row.original.delta.toFixed(3),
         },
         {
@@ -147,8 +151,9 @@ const RangesTablePanel = () => {
           accessor: 'multiplicity',
         },
         {
-          Header: 'Coupling',
+          Header: 'J (Hz)',
           accessor: 'coupling',
+          sortType: 'basic',
           Cell: ({ row }) => row.original.coupling.toFixed(3),
         },
       ],


### PR DESCRIPTION
usage of "basic" sorting of numeric values in React Tables (for numbers between 0 and 1) + showing of symbols and units in header of couplings (J) and delta (greek uppercase delta) of signals