### PR TITLE
Two fixes in context of molecules and setting reference values (sums) 

### DIFF
--- a/src/component/panels/MoleculePanel.jsx
+++ b/src/component/panels/MoleculePanel.jsx
@@ -119,17 +119,16 @@ const MoleculePanel = () => {
 
   useEffect(() => {
     if (molecules.length > 0) {
-      if (
-        activeTab &&
-        molecules[currentIndex] &&
-        // to consider only the first molecule as reference sum
-        // disable the following condition to use every current molecule as new reference
-        currentIndex === 0
-      ) {
+      if (activeTab) {
         const element = activeTab.replace(/[0-9]/g, '');
-        const elementsCount = molecules[currentIndex].atoms[element]
-          ? molecules[currentIndex].atoms[element]
-          : 0;
+        // use the next line instead of the second next line to use every current molecule as new reference and not only the first one
+        // and then update the dependencies of this useEffect() method
+        // const _currentIndex = currentIndex;
+        const _currentIndex = 0;
+        const elementsCount =
+          molecules[_currentIndex] && molecules[_currentIndex].atoms[element]
+            ? molecules[_currentIndex].atoms[element]
+            : 0;
         dispatch({ type: CHANGE_INTEGRAL_SUM, value: elementsCount });
         dispatch({ type: CHANGE_RANGE_SUM, value: elementsCount });
       }
@@ -138,7 +137,8 @@ const MoleculePanel = () => {
       dispatch({ type: CHANGE_INTEGRAL_SUM, value: 100 });
       dispatch({ type: CHANGE_RANGE_SUM, value: 100 });
     }
-  }, [activeTab, currentIndex, dispatch, molecules]);
+  }, [activeTab, dispatch, molecules]);
+  // }, [activeTab, currentIndex, dispatch, molecules]);#
 
   const handleClose = useCallback(
     (e) => {

--- a/src/component/panels/MoleculePanel.jsx
+++ b/src/component/panels/MoleculePanel.jsx
@@ -138,7 +138,7 @@ const MoleculePanel = () => {
       dispatch({ type: CHANGE_RANGE_SUM, value: 100 });
     }
   }, [activeTab, dispatch, molecules]);
-  // }, [activeTab, currentIndex, dispatch, molecules]);#
+  // }, [activeTab, currentIndex, dispatch, molecules]);
 
   const handleClose = useCallback(
     (e) => {

--- a/src/data/Analysis.js
+++ b/src/data/Analysis.js
@@ -93,18 +93,34 @@ export class Analysis {
     let molecule = Molecule.fromMolfile(molfile);
     let fragments = molecule.getFragments();
 
-    this.molecules = this.molecules.filter((m) => m.key !== key);
+    if (fragments.length > 1) {
+      this.molecules = this.molecules.filter((m) => m.key !== key);
 
-    for (let fragment of fragments) {
-      this.molecules.push(
-        new mol({
-          molfile: fragment.toMolfileV3(),
-          svg: fragment.toSVG(150, 150),
-          mf: fragment.getMolecularFormula().formula,
-          em: fragment.getMolecularFormula().absoluteWeight,
-          mw: fragment.getMolecularFormula().relativeWeight,
-        }),
-      );
+      for (let fragment of fragments) {
+        this.molecules.push(
+          new mol({
+            molfile: fragment.toMolfileV3(),
+            svg: fragment.toSVG(150, 150),
+            mf: fragment.getMolecularFormula().formula,
+            em: fragment.getMolecularFormula().absoluteWeight,
+            mw: fragment.getMolecularFormula().relativeWeight,
+          }),
+        );
+      }
+    } else if (fragments.length === 1) {
+      const fragment = fragments[0];
+      const _mol = new mol({
+        molfile: fragment.toMolfileV3(),
+        svg: fragment.toSVG(150, 150),
+        mf: fragment.getMolecularFormula().formula,
+        em: fragment.getMolecularFormula().absoluteWeight,
+        mw: fragment.getMolecularFormula().relativeWeight,
+        key: key,
+      });
+      let molIndex = this.molecules.findIndex((m) => m.key === key);
+      const _molecules = this.molecules.slice();
+      _molecules.splice(molIndex, 1, _mol);
+      this.molecules = _molecules;
     }
 
     return this.molecules;


### PR DESCRIPTION
1) sets now the correct reference value if the activeTab is switched and another molecule than the first one is in current view
2) when editing a molecule: if we save a fully connected molecule then it keeps its key and position in the molecules list, instead of deleting it and push a new molecule object at the list end (incl. new key)