### PR TITLE
reimplementing previous commits

### DIFF
--- a/src/component/1d/IntegralResizable.jsx
+++ b/src/component/1d/IntegralResizable.jsx
@@ -46,7 +46,7 @@ const IntegralResizable = ({ spectrumID, integralSeries, integralData }) => {
   const { height, margin } = useChartData();
   const { scaleX } = useScale();
 
-  const { id, value } = integralData;
+  const { id, absolute } = integralData;
 
   const highlight = useHighlight([id]);
 
@@ -122,7 +122,7 @@ const IntegralResizable = ({ spectrumID, integralSeries, integralData }) => {
             fill="black"
             style={{ fontSize: '12px', fontWeight: 'bold' }}
           >
-            {value.toFixed(2)}
+            {absolute.toFixed(2)}
           </text>
         )}
         <Resizable

--- a/src/component/modal/NumberInputModal.jsx
+++ b/src/component/modal/NumberInputModal.jsx
@@ -67,7 +67,11 @@ const NumberInputModal = ({ onSave, onClose, header }) => {
         </button>
       </div>
       <div className="container">
-        <input ref={valueReft} type="number" placeholder="Enter the new sum" />
+        <input
+          ref={valueReft}
+          type="number"
+          placeholder="Enter the new value"
+        />
         <button type="button" onClick={saveHandler}>
           Set
         </button>

--- a/src/component/panels/IntegralTablePanel.jsx
+++ b/src/component/panels/IntegralTablePanel.jsx
@@ -9,7 +9,6 @@ import { useModal } from '../elements/Modal';
 import ReactTable from '../elements/ReactTable/ReactTable';
 import Select from '../elements/Select';
 import ToolTip from '../elements/ToolTip/ToolTip';
-import ConnectToContext from '../hoc/ConnectToContext';
 import NumberInputModal from '../modal/NumberInputModal';
 import {
   DELETE_INTEGRAL,
@@ -52,307 +51,319 @@ const styles = {
 
 const selectStyle = { marginLeft: 10, marginRight: 10, border: 'none' };
 
-const IntegralTablePanel = memo(
-  ({ activeSpectrum, data: SpectrumsData, preferences, activeTab }) => {
-    // const {
-    //   activeSpectrum,
-    //   data: SpectrumsData,
-    //   preferences,
-    //   activeTab,
-    // } = useChartData();
-    const { xDomain } = useChartData();
-    const [filterIsActive, setFilterIsActive] = useState(false);
-    const [integralsCounter, setIntegralsCounter] = useState(0);
+const IntegralTablePanel = memo(() => {
+  const {
+    activeSpectrum,
+    data: SpectrumsData,
+    preferences,
+    activeTab,
+    xDomain,
+  } = useChartData();
+  const [filterIsActive, setFilterIsActive] = useState(false);
+  const [integralsCounter, setIntegralsCounter] = useState(0);
 
-    const dispatch = useDispatch();
-    const modal = useModal();
-    const [isFlipped, setFlipStatus] = useState(false);
-    const [isTableVisible, setTableVisibility] = useState(true);
-    const settingRef = useRef();
+  const dispatch = useDispatch();
+  const modal = useModal();
+  const [isFlipped, setFlipStatus] = useState(false);
+  const [isTableVisible, setTableVisibility] = useState(true);
+  const settingRef = useRef();
 
-    const deletePeakHandler = useCallback(
-      (e, row) => {
-        e.preventDefault();
-        e.stopPropagation();
-        const params = row.original;
-        dispatch({
-          type: DELETE_INTEGRAL,
-          integralID: params.id,
-        });
-      },
-      [dispatch],
-    );
-    const changeIntegralDataHandler = useCallback(
-      (value, row) => {
-        const data = { ...row.original, kind: value };
-        dispatch({
-          type: CHANGE_INTEGRAL_DATA,
-          data,
-        });
-      },
-      [dispatch],
-    );
-    const defaultColumns = [
-      {
-        orderIndex: 1,
-        Header: '#',
-        Cell: ({ row }) => row.index + 1,
-        width: 10,
-      },
+  const deleteIntegralHandler = useCallback(
+    (e, row) => {
+      e.preventDefault();
+      e.stopPropagation();
+      const params = row.original;
+      dispatch({
+        type: DELETE_INTEGRAL,
+        integralID: params.id,
+      });
+    },
+    [dispatch],
+  );
+  const changeIntegralDataHandler = useCallback(
+    (value, row) => {
+      const data = { ...row.original, kind: value };
+      dispatch({
+        type: CHANGE_INTEGRAL_DATA,
+        data,
+      });
+    },
+    [dispatch],
+  );
+  const defaultColumns = [
+    {
+      orderIndex: 1,
+      Header: '#',
+      Cell: ({ row }) => row.index + 1,
+      width: 10,
+    },
 
-      {
-        orderIndex: 2,
-        Header: 'From',
-        accessor: 'from',
+    {
+      orderIndex: 2,
+      Header: 'From',
+      accessor: 'from',
+      sortType: 'basic',
+      resizable: true,
+      Cell: ({ row }) => row.original.from.toFixed(2),
+    },
+    {
+      orderIndex: 3,
+      Header: 'To',
+      accessor: 'to',
+      sortType: 'basic',
+      resizable: true,
+      Cell: ({ row }) => row.original.to.toFixed(2),
+    },
+    {
+      orderIndex: 6,
+      Header: 'Kind',
+      accessor: 'kind',
+      sortType: 'basic',
+      resizable: true,
+      Cell: ({ row }) => (
+        <Select
+          onChange={(value) => changeIntegralDataHandler(value, row)}
+          data={SignalKinds}
+          style={selectStyle}
+          defaultValue={row.original.kind}
+        />
+      ),
+    },
+    {
+      orderIndex: 7,
+      Header: '',
+      id: 'delete-button',
+      Cell: ({ row }) => (
+        <button
+          type="button"
+          className="delete-button"
+          onClick={(e) => deleteIntegralHandler(e, row)}
+        >
+          <FaRegTrashAlt />
+        </button>
+      ),
+    },
+  ];
+
+  const checkPreferences = (integralsPreferences, key) => {
+    const val =
+      integralsPreferences === undefined ||
+      Object.keys(integralsPreferences).length === 0 ||
+      (integralsPreferences && integralsPreferences[key] === true)
+        ? true
+        : false;
+    return val;
+  };
+
+  const tableColumns = useMemo(() => {
+    const setCustomColumn = (array, index, columnLabel, cellHandler) => {
+      array.push({
+        orderIndex: index,
+        Header: columnLabel,
         sortType: 'basic',
-        resizable: true,
-        Cell: ({ row }) => row.original.from.toFixed(2),
-      },
-      {
-        orderIndex: 3,
-        Header: 'To',
-        accessor: 'to',
-        sortType: 'basic',
-        resizable: true,
-        Cell: ({ row }) => row.original.to.toFixed(2),
-      },
-      {
-        orderIndex: 6,
-        Header: 'Kind',
-        accessor: 'kind',
-        sortType: 'basic',
-        resizable: true,
-        Cell: ({ row }) => (
-          <Select
-            onChange={(value) => changeIntegralDataHandler(value, row)}
-            data={SignalKinds}
-            style={selectStyle}
-            defaultValue={row.original.kind}
-          />
-        ),
-      },
-      {
-        orderIndex: 7,
-        Header: '',
-        id: 'delete-button',
-        Cell: ({ row }) => (
-          <button
-            type="button"
-            className="delete-button"
-            onClick={(e) => deletePeakHandler(e, row)}
-          >
-            <FaRegTrashAlt />
-          </button>
-        ),
-      },
-    ];
-
-    const checkPreferences = (integralsPreferences, key) => {
-      const val =
-        integralsPreferences === undefined ||
-        Object.keys(integralsPreferences).length === 0 ||
-        (integralsPreferences && integralsPreferences[key] === true)
-          ? true
-          : false;
-      return val;
+        Cell: ({ row }) => cellHandler(row),
+      });
     };
 
-    const tableColumns = useMemo(() => {
-      const setCustomColumn = (array, index, columnLabel, cellHandler) => {
-        array.push({
-          orderIndex: index,
-          Header: columnLabel,
-          sortType: 'basic',
-          Cell: ({ row }) => cellHandler(row),
-        });
-      };
-
-      const integralsPreferences = lodash.get(
-        preferences,
-        `panels.integrals.[${activeTab}]`,
-      );
-      // if (integralsPreferences) {
-      let cols = [...defaultColumns];
-      if (checkPreferences(integralsPreferences, 'showValue')) {
-        setCustomColumn(cols, 4, 'Value', (row) =>
-          formatNumber(
-            row.original.value,
-            integralsPreferences &&
-              Object.prototype.hasOwnProperty.call(
-                integralsPreferences,
-                'valueFormat',
-              )
-              ? integralsPreferences.valueFormat
-              : integralDefaultValues.valueFormat,
-          ),
-        );
-      }
-      if (checkPreferences(integralsPreferences, 'showNB')) {
-        const n = activeTab && activeTab.replace(/[0-9]/g, '');
-        setCustomColumn(cols, 5, `nb ${n}`, (row) =>
-          formatNumber(
-            row.original.relative,
-            integralsPreferences &&
-              Object.prototype.hasOwnProperty.call(
-                integralsPreferences,
-                'NBFormat',
-              )
-              ? integralsPreferences.NBFormat
-              : integralDefaultValues.NBFormat,
-          ),
-        );
-      }
-
-      return cols.sort(
-        (object1, object2) => object1.orderIndex - object2.orderIndex,
-      );
-    }, [activeTab, defaultColumns, preferences]);
-
-    const data = useMemo(() => {
-      const _data =
-        activeSpectrum && SpectrumsData
-          ? SpectrumsData[activeSpectrum.index]
-          : null;
-
-      function isInRange(from, to) {
-        const factor = 10000;
-        to = to * factor;
-        from = from * factor;
-        return (
-          (to >= xDomain[0] * factor && from <= xDomain[1] * factor) ||
-          (from <= xDomain[0] * factor && to >= xDomain[1] * factor)
-        );
-      }
-
-      if (_data && _data.integrals && _data.integrals.values) {
-        setIntegralsCounter(_data.integrals.values.length);
-
-        const integrals = filterIsActive
-          ? _data.integrals.values.filter((integral) =>
-              isInRange(integral.from, integral.to),
+    const integralsPreferences = lodash.get(
+      preferences,
+      `panels.integrals.[${activeTab}]`,
+    );
+    // if (integralsPreferences) {
+    let cols = [...defaultColumns];
+    if (checkPreferences(integralsPreferences, 'showAbsolute')) {
+      setCustomColumn(cols, 4, 'Absolute', (row) =>
+        formatNumber(
+          row.original.absolute,
+          integralsPreferences &&
+            Object.prototype.hasOwnProperty.call(
+              integralsPreferences,
+              'absoluteFormat',
             )
-          : _data.integrals.values;
-
-        return integrals.map((integral) => {
-          return {
-            ...integral,
-            isConstantlyHighlighted: isInRange(integral.from, integral.to),
-          };
-        });
-      }
-    }, [SpectrumsData, activeSpectrum, filterIsActive, xDomain]);
-
-    const yesHandler = useCallback(() => {
-      dispatch({ type: DELETE_INTEGRAL, integralID: null });
-    }, [dispatch]);
-
-    const handleDeleteAll = useCallback(() => {
-      modal.showConfirmDialog('All records will be deleted,Are You sure?', {
-        onYes: yesHandler,
-      });
-    }, [modal, yesHandler]);
-
-    const changeIntegralSumHandler = useCallback(
-      (value) => {
-        if (value) {
-          dispatch({ type: CHANGE_INTEGRAL_SUM, value });
-        }
-
-        modal.close();
-      },
-      [dispatch, modal],
-    );
-
-    const showChangeIntegralSumModal = useCallback(() => {
-      modal.show(
-        <NumberInputModal
-          header="Set new integral sum"
-          onClose={() => modal.close()}
-          onSave={changeIntegralSumHandler}
-        />,
+            ? integralsPreferences.absoluteFormat
+            : integralDefaultValues.absoluteFormat,
+        ),
       );
-    }, [changeIntegralSumHandler, modal]);
+    }
+    if (checkPreferences(integralsPreferences, 'showNB')) {
+      const n = activeTab && activeTab.replace(/[0-9]/g, '');
+      setCustomColumn(cols, 5, `nb ${n}`, (row) =>
+        formatNumber(
+          row.original.integral,
+          integralsPreferences &&
+            Object.prototype.hasOwnProperty.call(
+              integralsPreferences,
+              'NBFormat',
+            )
+            ? integralsPreferences.NBFormat
+            : integralDefaultValues.NBFormat,
+        ),
+      );
+    }
 
-    const settingsPanelHandler = useCallback(() => {
-      setFlipStatus(!isFlipped);
-      if (!isFlipped) {
-        setTimeout(
-          () => {
-            setTableVisibility(false);
-          },
-          400,
-          isFlipped,
-        );
-      } else {
-        setTableVisibility(true);
-      }
-    }, [isFlipped]);
-
-    const saveSettingHandler = useCallback(() => {
-      settingRef.current.saveSetting();
-      setFlipStatus(false);
-      setTableVisibility(true);
-    }, []);
-
-    const handleOnFilter = useCallback(() => {
-      setFilterIsActive(!filterIsActive);
-    }, [filterIsActive]);
-
-    return (
-      <>
-        <div style={styles.container}>
-          {!isFlipped && (
-            <DefaultPanelHeader
-              counter={integralsCounter}
-              onDelete={handleDeleteAll}
-              deleteToolTip="Delete All Integrals"
-              onFilter={handleOnFilter}
-              filterToolTip={
-                filterIsActive
-                  ? 'Show all integrals'
-                  : 'Hide integrals out of view'
-              }
-              filterIsActive={filterIsActive}
-              counterFiltered={data && data.length}
-              showSettingButton="true"
-              onSettingClick={settingsPanelHandler}
-            >
-              <ToolTip title="Change Integrals sum" popupPlacement="right">
-                <button
-                  style={styles.sumButton}
-                  type="button"
-                  onClick={showChangeIntegralSumModal}
-                >
-                  Σ
-                </button>
-              </ToolTip>
-            </DefaultPanelHeader>
-          )}
-          {isFlipped && (
-            <PreferencesHeader
-              onSave={saveSettingHandler}
-              onClose={settingsPanelHandler}
-            />
-          )}
-
-          <ReactCardFlip
-            isFlipped={isFlipped}
-            infinite={true}
-            containerStyle={{ height: '100%' }}
-          >
-            <div style={!isTableVisible ? { display: 'none' } : {}}>
-              {data && data.length > 0 ? (
-                <ReactTable data={data} columns={tableColumns} />
-              ) : (
-                <NoTableData />
-              )}
-            </div>
-            <IntegralsPreferences data={SpectrumsData} ref={settingRef} />
-          </ReactCardFlip>
-        </div>
-      </>
+    return cols.sort(
+      (object1, object2) => object1.orderIndex - object2.orderIndex,
     );
-  },
-);
+  }, [activeTab, defaultColumns, preferences]);
 
-export default ConnectToContext(IntegralTablePanel, useChartData);
+  const data = useMemo(() => {
+    const _data =
+      activeSpectrum && SpectrumsData
+        ? SpectrumsData[activeSpectrum.index]
+        : null;
+
+    function isInRange(from, to) {
+      const factor = 10000;
+      to = to * factor;
+      from = from * factor;
+      return (
+        (to >= xDomain[0] * factor && from <= xDomain[1] * factor) ||
+        (from <= xDomain[0] * factor && to >= xDomain[1] * factor)
+      );
+    }
+
+    if (_data && _data.integrals && _data.integrals.values) {
+      setIntegralsCounter(_data.integrals.values.length);
+
+      const integrals = filterIsActive
+        ? _data.integrals.values.filter((integral) =>
+            isInRange(integral.from, integral.to),
+          )
+        : _data.integrals.values;
+
+      return integrals.map((integral) => {
+        return {
+          ...integral,
+          isConstantlyHighlighted: isInRange(integral.from, integral.to),
+        };
+      });
+    }
+  }, [SpectrumsData, activeSpectrum, filterIsActive, xDomain]);
+
+  const yesHandler = useCallback(() => {
+    dispatch({ type: DELETE_INTEGRAL, integralID: null });
+  }, [dispatch]);
+
+  const handleDeleteAll = useCallback(() => {
+    modal.showConfirmDialog('All records will be deleted,Are You sure?', {
+      onYes: yesHandler,
+    });
+  }, [modal, yesHandler]);
+
+  const changeIntegralSumHandler = useCallback(
+    (value) => {
+      if (value) {
+        dispatch({ type: CHANGE_INTEGRAL_SUM, value });
+      }
+
+      modal.close();
+    },
+    [dispatch, modal],
+  );
+
+  const elementsCount = useMemo(() => {
+    return activeSpectrum &&
+      SpectrumsData &&
+      SpectrumsData[activeSpectrum.index] &&
+      SpectrumsData[activeSpectrum.index].integrals &&
+      SpectrumsData[activeSpectrum.index].integrals.options &&
+      SpectrumsData[activeSpectrum.index].integrals.options.sum !== undefined
+      ? SpectrumsData[activeSpectrum.index].integrals.options.sum
+      : null;
+  }, [SpectrumsData, activeSpectrum]);
+
+  const showChangeIntegralSumModal = useCallback(() => {
+    modal.show(
+      <NumberInputModal
+        header={`Set new integral sum (current: ${elementsCount})`}
+        onClose={() => modal.close()}
+        onSave={changeIntegralSumHandler}
+      />,
+    );
+  }, [changeIntegralSumHandler, elementsCount, modal]);
+
+  const settingsPanelHandler = useCallback(() => {
+    setFlipStatus(!isFlipped);
+    if (!isFlipped) {
+      setTimeout(
+        () => {
+          setTableVisibility(false);
+        },
+        400,
+        isFlipped,
+      );
+    } else {
+      setTableVisibility(true);
+    }
+  }, [isFlipped]);
+
+  const saveSettingHandler = useCallback(() => {
+    settingRef.current.saveSetting();
+    setFlipStatus(false);
+    setTableVisibility(true);
+  }, []);
+
+  const handleOnFilter = useCallback(() => {
+    setFilterIsActive(!filterIsActive);
+  }, [filterIsActive]);
+
+  return (
+    <>
+      <div style={styles.container}>
+        {!isFlipped && (
+          <DefaultPanelHeader
+            counter={integralsCounter}
+            onDelete={handleDeleteAll}
+            deleteToolTip="Delete All Integrals"
+            onFilter={handleOnFilter}
+            filterToolTip={
+              filterIsActive
+                ? 'Show all integrals'
+                : 'Hide integrals out of view'
+            }
+            filterIsActive={filterIsActive}
+            counterFiltered={data && data.length}
+            showSettingButton="true"
+            onSettingClick={settingsPanelHandler}
+          >
+            <ToolTip
+              title={`Change Integrals sum (${elementsCount})`}
+              popupPlacement="right"
+            >
+              <button
+                style={styles.sumButton}
+                type="button"
+                onClick={showChangeIntegralSumModal}
+              >
+                Σ
+              </button>
+            </ToolTip>
+          </DefaultPanelHeader>
+        )}
+        {isFlipped && (
+          <PreferencesHeader
+            onSave={saveSettingHandler}
+            onClose={settingsPanelHandler}
+          />
+        )}
+
+        <ReactCardFlip
+          isFlipped={isFlipped}
+          infinite={true}
+          containerStyle={{ height: '100%' }}
+        >
+          <div style={!isTableVisible ? { display: 'none' } : {}}>
+            {data && data.length > 0 ? (
+              <ReactTable data={data} columns={tableColumns} />
+            ) : (
+              <NoTableData />
+            )}
+          </div>
+          <IntegralsPreferences data={SpectrumsData} ref={settingRef} />
+        </ReactCardFlip>
+      </div>
+    </>
+  );
+});
+
+export default IntegralTablePanel;

--- a/src/component/panels/RangesTablePanel.jsx
+++ b/src/component/panels/RangesTablePanel.jsx
@@ -1,3 +1,4 @@
+import lodash from 'lodash';
 import { X } from 'ml-spectra-processing';
 import React, { useCallback, useMemo, memo, useState } from 'react';
 import { useAlert } from 'react-alert';
@@ -11,7 +12,6 @@ import ReactTable from '../elements/ReactTable/ReactTable';
 import ReactTableExpandable from '../elements/ReactTable/ReactTableExpandable';
 import Select from '../elements/Select';
 import ToolTip from '../elements/ToolTip/ToolTip';
-import ConnectToContext from '../hoc/ConnectToContext';
 import CopyClipboardModal from '../modal/CopyClipboardModal';
 import NumberInputModal from '../modal/NumberInputModal';
 import {
@@ -20,10 +20,12 @@ import {
   CHANGE_RANGE_SUM,
 } from '../reducer/types/Types';
 import { copyTextToClipboard } from '../utility/Export';
+import formatNumber from '../utility/FormatNumber';
 
 import { SignalKinds } from './constants/SignalsKinds';
 import DefaultPanelHeader from './header/DefaultPanelHeader';
 import NoTableData from './placeholder/NoTableData';
+import { rangeDefaultValues } from './preferences-panels/defaultValues';
 
 const styles = {
   toolbar: {
@@ -50,9 +52,14 @@ const styles = {
 
 const selectStyle = { marginLeft: 10, marginRight: 10, border: 'none' };
 
-const RangesTablePanel = memo(({ data: SpectrumsData, activeSpectrum }) => {
-  // const { data: SpectrumsData, activeSpectrum } = useChartData();
-  const { xDomain } = useChartData();
+const RangesTablePanel = memo(() => {
+  const {
+    data: SpectrumsData,
+    activeSpectrum,
+    xDomain,
+    preferences,
+    activeTab,
+  } = useChartData();
   const [filterIsActive, setFilterIsActive] = useState(false);
   const [rangesCounter, setRangesCounter] = useState(0);
 
@@ -179,8 +186,9 @@ const RangesTablePanel = memo(({ data: SpectrumsData, activeSpectrum }) => {
   }, [closeClipBoardHandler, data, modal, saveToClipboardHandler]);
 
   // define columns for different (sub)tables and expandable ones
-  const columnsRanges = [
+  const columnsRangesDefault = [
     {
+      orderIndex: 1,
       Header: () => null,
       id: 'expander',
       Cell: ({ row }) => (
@@ -190,31 +198,24 @@ const RangesTablePanel = memo(({ data: SpectrumsData, activeSpectrum }) => {
       ),
     },
     {
+      orderIndex: 2,
       Header: '#',
       Cell: ({ row }) => row.index + 1,
     },
     {
+      orderIndex: 3,
       Header: 'From',
       accessor: 'from',
       Cell: ({ row }) => row.original.from.toFixed(2),
     },
     {
+      orderIndex: 4,
       Header: 'To',
       accessor: 'to',
       Cell: ({ row }) => row.original.to.toFixed(2),
     },
-
     {
-      Header: 'Absolute',
-      accessor: 'absolute',
-      Cell: ({ row }) => row.original.absolute.toFixed(1),
-    },
-    {
-      Header: 'Integral',
-      accessor: 'integral',
-      Cell: ({ row }) => row.original.integral.toFixed(1),
-    },
-    {
+      orderIndex: 7,
       Header: '#Signals',
       Cell: ({ row }) =>
         `${row.original.signal.length}: ${row.original.signal
@@ -222,6 +223,7 @@ const RangesTablePanel = memo(({ data: SpectrumsData, activeSpectrum }) => {
           .join(',')}`,
     },
     {
+      orderIndex: 8,
       Header: 'Kind',
       accessor: 'kind',
       sortType: 'basic',
@@ -236,6 +238,7 @@ const RangesTablePanel = memo(({ data: SpectrumsData, activeSpectrum }) => {
       ),
     },
     {
+      orderIndex: 9,
       Header: '',
       id: 'delete-button',
       Cell: ({ row }) => (
@@ -249,6 +252,68 @@ const RangesTablePanel = memo(({ data: SpectrumsData, activeSpectrum }) => {
       ),
     },
   ];
+
+  const checkPreferences = (rangesPreferences, key) => {
+    const val =
+      rangesPreferences === undefined ||
+      Object.keys(rangesPreferences).length === 0 ||
+      (rangesPreferences && rangesPreferences[key] === true)
+        ? true
+        : false;
+    return val;
+  };
+
+  const columnsRanges = useMemo(() => {
+    const setCustomColumn = (array, index, columnLabel, cellHandler) => {
+      array.push({
+        orderIndex: index,
+        Header: columnLabel,
+        sortType: 'basic',
+        Cell: ({ row }) => cellHandler(row),
+      });
+    };
+
+    const rangesPreferences = lodash.get(
+      preferences,
+      `panels.ranges.[${activeTab}]`,
+    );
+    let cols = [...columnsRangesDefault];
+    if (checkPreferences(rangesPreferences, 'showAbsolute')) {
+      setCustomColumn(cols, 5, 'Absolute', (row) =>
+        formatNumber(
+          row.original.absolute,
+          rangesPreferences &&
+            Object.prototype.hasOwnProperty.call(
+              rangesPreferences,
+              'absoluteFormat',
+            )
+            ? rangesPreferences.absoluteFormat
+            : rangeDefaultValues.absoluteFormat,
+        ),
+      );
+    }
+    if (checkPreferences(rangesPreferences, 'showNB')) {
+      const n = activeTab && activeTab.replace(/[0-9]/g, '');
+      setCustomColumn(cols, 6, `nb ${n}`, (row) => {
+        return row.original.integral
+          ? formatNumber(
+              row.original.integral,
+              rangesPreferences &&
+                Object.prototype.hasOwnProperty.call(
+                  rangesPreferences,
+                  'NBFormat',
+                )
+                ? rangesPreferences.NBFormat
+                : rangeDefaultValues.NBFormat,
+            )
+          : null;
+      });
+    }
+
+    return cols.sort(
+      (object1, object2) => object1.orderIndex - object2.orderIndex,
+    );
+  }, [activeTab, columnsRangesDefault, preferences]);
 
   const columnsSignals = [
     {
@@ -351,15 +416,26 @@ const RangesTablePanel = memo(({ data: SpectrumsData, activeSpectrum }) => {
     [dispatch, modal],
   );
 
+  const elementsCount = useMemo(() => {
+    return activeSpectrum &&
+      SpectrumsData &&
+      SpectrumsData[activeSpectrum.index] &&
+      SpectrumsData[activeSpectrum.index].ranges &&
+      SpectrumsData[activeSpectrum.index].ranges.options &&
+      SpectrumsData[activeSpectrum.index].ranges.options.sum !== undefined
+      ? SpectrumsData[activeSpectrum.index].ranges.options.sum
+      : null;
+  }, [SpectrumsData, activeSpectrum]);
+
   const showChangeRangesSumModal = useCallback(() => {
     modal.show(
       <NumberInputModal
-        header="Set new range sum"
+        header={`Set new range sum (current: ${elementsCount})`}
         onClose={() => modal.close()}
         onSave={changeRangesSumHandler}
       />,
     );
-  }, [changeRangesSumHandler, modal]);
+  }, [changeRangesSumHandler, elementsCount, modal]);
 
   const handleOnFilter = useCallback(() => {
     setFilterIsActive(!filterIsActive);
@@ -387,7 +463,10 @@ const RangesTablePanel = memo(({ data: SpectrumsData, activeSpectrum }) => {
             <FaFileExport />
           </button>
         </ToolTip>
-        <ToolTip title="Change Ranges sum" popupPlacement="right">
+        <ToolTip
+          title={`Change Ranges sum (${elementsCount})`}
+          popupPlacement="right"
+        >
           <button
             style={styles.sumButton}
             type="button"
@@ -412,4 +491,4 @@ const RangesTablePanel = memo(({ data: SpectrumsData, activeSpectrum }) => {
   );
 });
 
-export default ConnectToContext(RangesTablePanel, useChartData);
+export default RangesTablePanel;

--- a/src/component/panels/preferences-panels/IntegralsPreferences.jsx
+++ b/src/component/panels/preferences-panels/IntegralsPreferences.jsx
@@ -53,8 +53,8 @@ const styles = {
 };
 
 const defaultValues = {
-  showValue: true,
-  valueFormat: '0.00',
+  showAbsolute: true,
+  absoluteFormat: '0.00',
   showNB: true,
   NBFormat: '0.00',
 };
@@ -134,9 +134,9 @@ const IntegralsPreferences = forwardRef((props, ref) => {
   const formatFields = [
     {
       id: 1,
-      label: 'Value :',
-      checkController: 'showValue',
-      formatController: 'valueFormat',
+      label: 'Absolute :',
+      checkController: 'showAbsolute',
+      formatController: 'absoluteFormat',
       defaultFormat: '0.00',
     },
     {

--- a/src/component/panels/preferences-panels/defaultValues.js
+++ b/src/component/panels/preferences-panels/defaultValues.js
@@ -1,6 +1,13 @@
 const integralDefaultValues = {
-  showValue: true,
-  valueFormat: '0.00',
+  showAbsolute: true,
+  absoluteFormat: '0.00',
+  showNB: true,
+  NBFormat: '0.00',
+};
+
+const rangeDefaultValues = {
+  showAbsolute: true,
+  absoluteFormat: '0.00',
   showNB: true,
   NBFormat: '0.00',
 };
@@ -20,4 +27,4 @@ const peaksDefaultValues = {
   intensityFormat: '0.00',
 };
 
-export { peaksDefaultValues, integralDefaultValues };
+export { peaksDefaultValues, integralDefaultValues, rangeDefaultValues };

--- a/src/component/reducer/actions/RangesActions.js
+++ b/src/component/reducer/actions/RangesActions.js
@@ -41,7 +41,7 @@ const handleResizeRange = (state, action) => {
     if (state.activeSpectrum) {
       const { id, index } = state.activeSpectrum;
       const datumObject = AnalysisObj.getDatum(id);
-      datumObject.resizeRange(action.data);
+      datumObject.changeRange(action.data);
       draft.data[index].ranges = datumObject.getRanges();
     }
   });

--- a/src/data/Analysis.js
+++ b/src/data/Analysis.js
@@ -93,18 +93,34 @@ export class Analysis {
     let molecule = Molecule.fromMolfile(molfile);
     let fragments = molecule.getFragments();
 
-    this.molecules = this.molecules.filter((m) => m.key !== key);
+    if (fragments.length > 1) {
+      this.molecules = this.molecules.filter((m) => m.key !== key);
 
-    for (let fragment of fragments) {
-      this.molecules.push(
-        new mol({
-          molfile: fragment.toMolfileV3(),
-          svg: fragment.toSVG(150, 150),
-          mf: fragment.getMolecularFormula().formula,
-          em: fragment.getMolecularFormula().absoluteWeight,
-          mw: fragment.getMolecularFormula().relativeWeight,
-        }),
-      );
+      for (let fragment of fragments) {
+        this.molecules.push(
+          new mol({
+            molfile: fragment.toMolfileV3(),
+            svg: fragment.toSVG(150, 150),
+            mf: fragment.getMolecularFormula().formula,
+            em: fragment.getMolecularFormula().absoluteWeight,
+            mw: fragment.getMolecularFormula().relativeWeight,
+          }),
+        );
+      }
+    } else if (fragments.length === 1) {
+      const fragment = fragments[0];
+      const _mol = new mol({
+        molfile: fragment.toMolfileV3(),
+        svg: fragment.toSVG(150, 150),
+        mf: fragment.getMolecularFormula().formula,
+        em: fragment.getMolecularFormula().absoluteWeight,
+        mw: fragment.getMolecularFormula().relativeWeight,
+        key: key,
+      });
+      let molIndex = this.molecules.findIndex((m) => m.key === key);
+      const _molecules = this.molecules.slice();
+      _molecules.splice(molIndex, 1, _mol);
+      this.molecules = _molecules;
     }
 
     return this.molecules;
@@ -168,6 +184,7 @@ export class Analysis {
             peaks: ob.peaks,
             integrals: ob.integrals,
             filters: ob.filters,
+            ranges: ob.ranges,
           };
         })
       : [];

--- a/src/data/data1d/detectSignal.js
+++ b/src/data/data1d/detectSignal.js
@@ -1,0 +1,34 @@
+import { X } from 'ml-spectra-processing';
+import { analyseMultiplet } from 'multiplet-analysis';
+
+const detectSignal = (x, re, from, to, frequency) => {
+  const { fromIndex, toIndex } = X.getFromToIndex(x, {
+    from: from,
+    to: to,
+  });
+  const data = {
+    x: x.slice(fromIndex, toIndex),
+    y: re.slice(fromIndex, toIndex),
+  };
+
+  const result = analyseMultiplet(data, {
+    frequency: frequency,
+    takeBestPartMultiplet: true,
+    symmetrizeEachStep: true,
+  });
+
+  return {
+    nbAtoms: 0,
+    diaD: [],
+    multiplicity: result.j.map((j) => j.multiplicity).join(''),
+    kind: '',
+    remark: '',
+    peak: [], // @TODO receive peaks from result in future?
+    delta: result.chemShift,
+    j: result.j,
+    from: from,
+    to: to,
+  };
+};
+
+export default detectSignal;


### PR DESCRIPTION
- when editing a molecule: if we save a fully connected molecule then it keeps its key and position in the molecules list, instead of deleting it and push a new molecule object at the list end (incl. new keys)
- changed name fields in Integral to "absolute" and "integral"; 
- integrals and ranges with kind different than "signal" are not considered for relative number of element (e.g. total number of H's) anymore
- modifications towards a more general method for updating relative values (updateRelatives() )
- fix: Analysis.js -> add missing ranges to returned object
- sets the options.sum for ranges and integrals in Datum1D constructor to default of 100
- a new separate detectSignal() method and class
- from/to values for signals are stored now, for each signal within ranges
- hovering over the sum symbol shows now the current sum and it appears also the in modal header if the user wants to change the sum value