### PR TITLE
Bugfix, issue closes and non-signal ranges appear semi transparent

### DIFF
--- a/src/component/1d/IntegralResizable.jsx
+++ b/src/component/1d/IntegralResizable.jsx
@@ -46,7 +46,7 @@ const IntegralResizable = ({ spectrumID, integralSeries, integralData }) => {
   const { height, margin } = useChartData();
   const { scaleX } = useScale();
 
-  const { id, absolute } = integralData;
+  const { id, integral } = integralData;
 
   const highlight = useHighlight([id]);
 
@@ -122,7 +122,7 @@ const IntegralResizable = ({ spectrumID, integralSeries, integralData }) => {
             fill="black"
             style={{ fontSize: '12px', fontWeight: 'bold' }}
           >
-            {absolute.toFixed(2)}
+            {integral.toFixed(2)}
           </text>
         )}
         <Resizable

--- a/src/component/1d/IntegralResizable.jsx
+++ b/src/component/1d/IntegralResizable.jsx
@@ -122,7 +122,7 @@ const IntegralResizable = ({ spectrumID, integralSeries, integralData }) => {
             fill="black"
             style={{ fontSize: '12px', fontWeight: 'bold' }}
           >
-            {integral.toFixed(2)}
+            {integral !== undefined ? integral.toFixed(2) : ''}
           </text>
         )}
         <Resizable

--- a/src/component/1d/Range.jsx
+++ b/src/component/1d/Range.jsx
@@ -100,6 +100,7 @@ const Range = ({ rangeData }) => {
           height="6"
           className="range-area"
           fill="green"
+          fillOpacity={integral > 0 || highlight.isActive ? 1 : 0.4}
         />
         <text
           textAnchor="middle"
@@ -107,6 +108,7 @@ const Range = ({ rangeData }) => {
           y="20"
           fontSize="10"
           fill="red"
+          fillOpacity={integral > 0 || highlight.isActive ? 1 : 0.4}
         >
           {integral.toFixed(2)}
         </text>

--- a/src/component/1d/Range.jsx
+++ b/src/component/1d/Range.jsx
@@ -100,7 +100,11 @@ const Range = ({ rangeData }) => {
           height="6"
           className="range-area"
           fill="green"
-          fillOpacity={integral > 0 || highlight.isActive ? 1 : 0.4}
+          fillOpacity={
+            (integral !== undefined && integral > 0) || highlight.isActive
+              ? 1
+              : 0.4
+          }
         />
         <text
           textAnchor="middle"
@@ -108,9 +112,13 @@ const Range = ({ rangeData }) => {
           y="20"
           fontSize="10"
           fill="red"
-          fillOpacity={integral > 0 || highlight.isActive ? 1 : 0.4}
+          fillOpacity={
+            (integral !== undefined && integral > 0) || highlight.isActive
+              ? 1
+              : 0.4
+          }
         >
-          {integral.toFixed(2)}
+          {integral !== undefined ? integral.toFixed(2) : ''}
         </text>
       </g>
       <Resizable

--- a/src/component/panels/IntegralTablePanel.jsx
+++ b/src/component/panels/IntegralTablePanel.jsx
@@ -189,8 +189,8 @@ const IntegralTablePanel = memo(() => {
     }
     if (checkPreferences(integralsPreferences, 'showRelative')) {
       const n = activeTab && activeTab.replace(/[0-9]/g, '');
-      setCustomColumn(cols, 5, `Relative ${n}`, (row) =>
-        formatNumber(
+      setCustomColumn(cols, 5, `Relative ${n}`, (row) => {
+        const formattedNumber = formatNumber(
           row.original.integral,
           integralsPreferences &&
             Object.prototype.hasOwnProperty.call(
@@ -199,8 +199,12 @@ const IntegralTablePanel = memo(() => {
             )
             ? integralsPreferences.relativeFormat
             : integralDefaultValues.relativeFormat,
-        ),
-      );
+        );
+
+        return row.original.integral > 0
+          ? formattedNumber
+          : `[${formattedNumber}]`;
+      });
     }
 
     return cols.sort(

--- a/src/component/panels/PeaksTablePanel.jsx
+++ b/src/component/panels/PeaksTablePanel.jsx
@@ -147,7 +147,7 @@ const PeaksTablePanel = memo(
         }
         if (peaksPreferences.showDeltaHz) {
           setCustomColumn(cols, 4, 'δ (Hz)', (row) =>
-            formatNumber(row.original.value, peaksPreferences.deltaHzFormat),
+            formatNumber(row.original.valueHz, peaksPreferences.deltaHzFormat),
           );
         }
         if (peaksPreferences.showIntensity) {
@@ -197,6 +197,7 @@ const PeaksTablePanel = memo(
           return {
             xIndex: peak.xIndex,
             value: value,
+            valueHz: value * _data.info.frequency,
             id: peak.id,
             yValue: _data.y[peak.xIndex],
             peakWidth: peak.width ? peak.width : '',

--- a/src/component/panels/PeaksTablePanel.jsx
+++ b/src/component/panels/PeaksTablePanel.jsx
@@ -197,7 +197,10 @@ const PeaksTablePanel = memo(
           return {
             xIndex: peak.xIndex,
             value: value,
-            valueHz: value * _data.info.frequency,
+            valueHz:
+              _data.info && _data.info.frequency
+                ? value * _data.info.frequency
+                : '',
             id: peak.id,
             yValue: _data.y[peak.xIndex],
             peakWidth: peak.width ? peak.width : '',

--- a/src/component/panels/RangesTablePanel.jsx
+++ b/src/component/panels/RangesTablePanel.jsx
@@ -296,18 +296,19 @@ const RangesTablePanel = memo(() => {
     if (checkPreferences(rangesPreferences, 'showRelative')) {
       const n = activeTab && activeTab.replace(/[0-9]/g, '');
       setCustomColumn(cols, 6, `Relative ${n}`, (row) => {
-        return row.original.integral
-          ? formatNumber(
-              row.original.integral,
-              rangesPreferences &&
-                Object.prototype.hasOwnProperty.call(
-                  rangesPreferences,
-                  'relativeFormat',
-                )
-                ? rangesPreferences.relativeFormat
-                : rangeDefaultValues.relativeFormat,
+        const formattedNumber = formatNumber(
+          row.original.integral,
+          rangesPreferences &&
+            Object.prototype.hasOwnProperty.call(
+              rangesPreferences,
+              'relativeFormat',
             )
-          : null;
+            ? rangesPreferences.relativeFormat
+            : rangeDefaultValues.relativeFormat,
+        );
+        return row.original.integral > 0
+          ? formattedNumber
+          : `[${formattedNumber}]`;
       });
     }
 

--- a/src/data/data1d/Datum1D.js
+++ b/src/data/data1d/Datum1D.js
@@ -219,7 +219,7 @@ export class Datum1D {
     return values.map((value) => {
       return value.kind && kinds.includes(value.kind)
         ? { ...value, [storageKey]: value.absolute * factor }
-        : { ...value, [storageKey]: null };
+        : { ...value, [storageKey]: 0.0 };
     });
   }
 


### PR DESCRIPTION
- bugfix: #454 
- peak value (Hz) in table is shown in Hz now: #428 
- replaced absolute by relative value at the bottom of Integrals, the other part (coloring) was already done by @hamed-musallam if I saw it correctly: #433 
- excluded relative integral values in tables are now displayed in brackets -> [0.00]
- non-signal ranges in spectrum appear semi transparent (green rectangle and label)