### PR TITLE
Fixing

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "@emotion/core": "^10.0.28",
     "brukerconverter": "^2.1.2",
     "cheminfo-font": "^0.25.0",
-    "nmr-processing": "^0.0.1",
+    "nmr-processing": "^0.1.1",
     "d3": "^5.16.0",
     "file-saver": "^2.0.2",
     "immer": "^6.0.5",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "@emotion/core": "^10.0.28",
     "brukerconverter": "^2.1.2",
     "cheminfo-font": "^0.25.0",
+    "nmr-processing": "^0.0.1",
     "d3": "^5.16.0",
     "file-saver": "^2.0.2",
     "immer": "^6.0.5",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "ml-fft": "^1.3.5",
     "ml-gsd": "^4.0.0",
     "ml-regression-polynomial": "^2.1.0",
-    "ml-spectra-processing": "^3.0.2",
+    "ml-spectra-processing": "^4.0.0",
     "mouse-speed": "^2.0.1",
     "multiplet-analysis": "0.1.0",
     "numeral": "^2.0.6",

--- a/src/component/header/AutoPeakPickingOptionPanel.jsx
+++ b/src/component/header/AutoPeakPickingOptionPanel.jsx
@@ -34,6 +34,7 @@ const AutoPeakPickingOptionPanel = () => {
   const dispatch = useDispatch();
   const minMaxRatioRef = useRef();
   const maxNumberOfPeaksRef = useRef();
+  const noiseFactor = useRef();
 
   const handleApplyFilter = useCallback(() => {
     dispatch({
@@ -41,6 +42,7 @@ const AutoPeakPickingOptionPanel = () => {
       options: {
         maxNumberOfPeaks: maxNumberOfPeaksRef.current.value,
         minMaxRatio: minMaxRatioRef.current.value,
+        noiseFactor: noiseFactor.current.value,
       },
     });
   }, [dispatch]);
@@ -64,6 +66,17 @@ const AutoPeakPickingOptionPanel = () => {
         }}
         defaultValue={50}
       />
+       <NumberInput
+        ref={noiseFactor}
+        label="Noise factor"
+        name="noiseFactor"
+        style={{
+          input: styles.input,
+          inputContainer: styles.inputContainer,
+          label: styles.label,
+        }}
+        defaultValue={3}
+      />
       <NumberInput
         ref={minMaxRatioRef}
         label="Min Max Ratio:"
@@ -74,7 +87,7 @@ const AutoPeakPickingOptionPanel = () => {
           label: styles.label,
         }}
         defaultValue={0.1}
-        step="0.1"
+        step="0.01"
       />
 
       <button

--- a/src/component/header/RangesPickingOptionPanel.jsx
+++ b/src/component/header/RangesPickingOptionPanel.jsx
@@ -46,8 +46,8 @@ const RangesPickingOptionPanel = () => {
         minMaxRatio: 0.05,
         nH: 100,
         compile: true,
-        frequencyCluster: 16,
-        clean: null,
+        frequencyCluster: 3,
+        clean: true,
         keepPeaks: true,
       },
     });

--- a/src/component/header/RangesPickingOptionPanel.jsx
+++ b/src/component/header/RangesPickingOptionPanel.jsx
@@ -43,12 +43,14 @@ const RangesPickingOptionPanel = () => {
     dispatch({
       type: AUTO_RANGES_DETECTION,
       options: {
-        minMaxRatio: 0.05,
-        nH: 100,
-        compile: true,
-        frequencyCluster: 3,
-        clean: true,
-        keepPeaks: true,
+        peakPicking: {
+          minMaxRatio: 0.05,
+          nH: 100,
+          compile: false,
+          frequencyCluster: 16,
+          clean: true,
+          keepPeaks: true,
+        },
       },
     });
   }, [dispatch]);

--- a/src/data/data1d/autoPeakPicking.js
+++ b/src/data/data1d/autoPeakPicking.js
@@ -1,5 +1,5 @@
 import median from 'ml-array-median';
-import * as SD from 'spectra-data';
+import { autoPeaksPicking } from 'nmr-processing';
 
 import generateID from '../utilities/generateID';
 
@@ -8,15 +8,18 @@ export default function autoPeakPicking(datum1D, options) {
   // we calculate the noise but this could be improved
   let noise = median(datum1D.data.re.map((y) => Math.abs(y)));
 
-  const spectrum = SD.NMR.fromXY(datum1D.data.x, datum1D.data.re);
-  let peaks = spectrum.createPeaks({
-    noiseLevel: noise * 5,
-    minMaxRatio: minMaxRatio, // Threshold to determine if a given peak should be considered as a noise
-    realTopDetection: true,
-    maxCriteria: true,
-    smoothY: false,
-    sgOptions: { windowSize: 7, polynomial: 3 },
-  });
+  let { re, x } = datum1D.data;
+  let peaks = autoPeaksPicking(
+    { x, y: re },
+    {
+      // noiseLevel: noise * 2,
+      minMaxRatio: minMaxRatio, // Threshold to determine if a given peak should be considered as a noise
+      realTopDetection: true,
+      maxCriteria: true,
+      smoothY: false,
+      sgOptions: { windowSize: 15, polynomial: 3 },
+    },
+  );
 
   peaks.sort((a, b) => b.y - a.y);
   if (maxNumberOfPeaks) peaks = peaks.slice(0, maxNumberOfPeaks);

--- a/src/data/data1d/autoPeakPicking.js
+++ b/src/data/data1d/autoPeakPicking.js
@@ -4,7 +4,7 @@ import { autoPeaksPicking } from 'nmr-processing';
 import generateID from '../utilities/generateID';
 
 export default function autoPeakPicking(datum1D, options) {
-  const { minMaxRatio, maxNumberOfPeaks } = options;
+  const { minMaxRatio, maxNumberOfPeaks, noiseFactor } = options;
   // we calculate the noise but this could be improved
   let noise = median(datum1D.data.re.map((y) => Math.abs(y)));
 
@@ -12,7 +12,7 @@ export default function autoPeakPicking(datum1D, options) {
   let peaks = autoPeaksPicking(
     { x, y: re },
     {
-      // noiseLevel: noise * 2,
+      noiseLevel: noise * noiseFactor,
       minMaxRatio: minMaxRatio, // Threshold to determine if a given peak should be considered as a noise
       realTopDetection: true,
       maxCriteria: true,
@@ -20,9 +20,11 @@ export default function autoPeakPicking(datum1D, options) {
       sgOptions: { windowSize: 15, polynomial: 3 },
     },
   );
-
+    console.log('data', peaks.slice());
   peaks.sort((a, b) => b.y - a.y);
-  if (maxNumberOfPeaks) peaks = peaks.slice(0, maxNumberOfPeaks);
+  console.log(maxNumberOfPeaks, peaks.length);
+  console.log(peaks)
+  if (maxNumberOfPeaks < peaks.length) peaks = peaks.slice(0, maxNumberOfPeaks);
 
   return peaks.map((peak) => {
     return {

--- a/src/data/data1d/autoPeakPicking.js
+++ b/src/data/data1d/autoPeakPicking.js
@@ -1,15 +1,15 @@
 import median from 'ml-array-median';
-import { autoPeaksPicking } from 'nmr-processing';
+import { xyAutoPeaksPicking } from 'nmr-processing';
 
 import generateID from '../utilities/generateID';
 
 export default function autoPeakPicking(datum1D, options) {
   const { minMaxRatio, maxNumberOfPeaks, noiseFactor } = options;
   // we calculate the noise but this could be improved
-  let noise = median(datum1D.data.re.map((y) => Math.abs(y)));
+  const noise = median(datum1D.data.re.map((y) => Math.abs(y)));
 
-  let { re, x } = datum1D.data;
-  let peaks = autoPeaksPicking(
+  const { re, x } = datum1D.data;
+  let peaks = xyAutoPeaksPicking(
     { x, y: re },
     {
       noiseLevel: noise * noiseFactor,
@@ -20,10 +20,7 @@ export default function autoPeakPicking(datum1D, options) {
       sgOptions: { windowSize: 15, polynomial: 3 },
     },
   );
-    console.log('data', peaks.slice());
   peaks.sort((a, b) => b.y - a.y);
-  console.log(maxNumberOfPeaks, peaks.length);
-  console.log(peaks)
   if (maxNumberOfPeaks < peaks.length) peaks = peaks.slice(0, maxNumberOfPeaks);
 
   return peaks.map((peak) => {

--- a/src/data/data1d/autoRangesDetection.js
+++ b/src/data/data1d/autoRangesDetection.js
@@ -1,38 +1,40 @@
-import { autoRangesPicking } from 'nmr-processing';
+import { xyAutoRangesPicking } from 'nmr-processing';
 
-export default function autoRangesDetection(datum1D, options) {
-  const {
-    minMaxRatio = 0.1,
-    nH = 100,
-    compile = true,
-    frequencyCluster = 16,
-    clean = null,
-    keepPeaks = true,
-  } = options;
+let defaultOptions = {
+  peakPicking: {
+    minMaxRatio: 0.05,
+    realTopDetection: true,
+    maxCriteria: true,
+    smoothY: false,
+    nH: 100,
+    compile: true,
+    frequencyCluster: 16,
+    clean: true,
+    keepPeaks: true,
+    sgOptions: { windowSize: 7, polynomial: 3 },
+  },
+};
+
+export default function autoRangesDetection(datum1D, options = {}) {
   // we calculate the noise but this could be improved
   let noise = datum1D.data.re.map((y) => Math.abs(y)).sort()[
     Math.floor(datum1D.data.re.length / 2)
   ];
 
-  let { frequency, nucleus } = datum1D.info;
-  let { re, x } = datum1D.data;
-  const ranges = autoRangesPicking(
-    { x, y: re },
+  const { re, x } = datum1D.data;
+  const { frequency, nucleus } = datum1D.info;
+
+  options.peakPicking = Object.assign(
+    {},
+    defaultOptions.peakPicking,
+    options.peakPicking,
     {
-      noiseLevel: noise * 3,
-      minMaxRatio: minMaxRatio, // Threshold to determine if a given peak should be considered as a noise
-      realTopDetection: true,
-      maxCriteria: true,
-      smoothY: false,
-      nH,
-      compile,
       frequency,
       nucleus,
-      frequencyCluster,
-      clean,
-      keepPeaks,
-      sgOptions: { windowSize: 7, polynomial: 3 },
+      noiseLevel: 3 * noise,
     },
   );
+
+  const ranges = xyAutoRangesPicking({ x, y: re }, options);
   return ranges;
 }

--- a/src/data/data1d/autoRangesDetection.js
+++ b/src/data/data1d/autoRangesDetection.js
@@ -1,4 +1,4 @@
-import * as SD from 'spectra-data';
+import { autoRangesPicking } from 'nmr-processing';
 
 export default function autoRangesDetection(datum1D, options) {
   const {
@@ -13,20 +13,26 @@ export default function autoRangesDetection(datum1D, options) {
   let noise = datum1D.data.re.map((y) => Math.abs(y)).sort()[
     Math.floor(datum1D.data.re.length / 2)
   ];
-  const spectrum = SD.NMR.fromXY(datum1D.data.x, datum1D.data.re);
-  const ranges = spectrum.createRanges({
-    noiseLevel: noise * 3,
-    minMaxRatio: minMaxRatio, // Threshold to determine if a given peak should be considered as a noise
-    realTopDetection: true,
-    maxCriteria: true,
-    smoothY: false,
-    nH,
-    compile,
-    frequencyCluster,
-    clean,
-    keepPeaks,
-    sgOptions: { windowSize: 7, polynomial: 3 },
-  });
 
+  let { frequency, nucleus } = datum1D.info;
+  let { re, x } = datum1D.data;
+  const ranges = autoRangesPicking(
+    { x, y: re },
+    {
+      noiseLevel: noise * 3,
+      minMaxRatio: minMaxRatio, // Threshold to determine if a given peak should be considered as a noise
+      realTopDetection: true,
+      maxCriteria: true,
+      smoothY: false,
+      nH,
+      compile,
+      frequency,
+      nucleus,
+      frequencyCluster,
+      clean,
+      keepPeaks,
+      sgOptions: { windowSize: 7, polynomial: 3 },
+    },
+  );
   return ranges;
 }

--- a/src/data/data1d/filter1d/autoPhaseCorrection.js
+++ b/src/data/data1d/filter1d/autoPhaseCorrection.js
@@ -11,13 +11,19 @@ export const name = 'automatic phase correction';
  * @param {number} [options.ph1=0]
  */
 
+const defaultOptions = {
+  magnitudeMode: false,
+  minRegSize: 30,
+  maxDistanceToJoin: 256
+}
+
 export function apply(datum1D, options = {}) {
   if (!isApplicable(datum1D)) {
     throw new Error('phaseCorrection not applicable on this data');
   }
-  let { minRegSize = 256 } = options;
+  Object.assign(defaultOptions, options);
 
-  return reimAutoPhaseCorrection(datum1D.data, { minRegSize });
+  return reimAutoPhaseCorrection(datum1D.data, options);
 }
 
 export function isApplicable(datum1D) {

--- a/src/data/data1d/filter1d/autoPhaseCorrection.js
+++ b/src/data/data1d/filter1d/autoPhaseCorrection.js
@@ -21,7 +21,7 @@ export function apply(datum1D, options = {}) {
   if (!isApplicable(datum1D)) {
     throw new Error('phaseCorrection not applicable on this data');
   }
-  Object.assign(defaultOptions, options);
+  options = Object.assign({}, defaultOptions, options);
 
   return reimAutoPhaseCorrection(datum1D.data, options);
 }

--- a/src/data/data1d/filter1d/autoPhaseCorrection.js
+++ b/src/data/data1d/filter1d/autoPhaseCorrection.js
@@ -14,8 +14,8 @@ export const name = 'automatic phase correction';
 const defaultOptions = {
   magnitudeMode: false,
   minRegSize: 30,
-  maxDistanceToJoin: 256
-}
+  maxDistanceToJoin: 256,
+};
 
 export function apply(datum1D, options = {}) {
   if (!isApplicable(datum1D)) {

--- a/src/data/data1d/filter1d/digitalFilter.js
+++ b/src/data/data1d/filter1d/digitalFilter.js
@@ -16,7 +16,6 @@ export function apply(datum1D, options = {}) {
   let im = new Float64Array(datum1D.data.im);
 
   let pointsToShift = Math.floor(digitalFilterValue);
-  let ph1 = pointsToShift - digitalFilterValue;
 
   const skip = 0;
   pointsToShift += 0;

--- a/src/data/data1d/filter1d/digitalFilter.js
+++ b/src/data/data1d/filter1d/digitalFilter.js
@@ -1,5 +1,3 @@
-import { reimPhaseCorrection } from 'ml-spectra-processing';
-
 export const id = 'digitalFilter';
 export const name = 'Digital Filter';
 
@@ -32,11 +30,6 @@ export function apply(datum1D, options = {}) {
 
   datum1D.data.re = newRe;
   datum1D.data.im = newIm;
-
-  if (ph1 !== 0) {
-    ph1 *= Math.PI * 2;
-    Object.assign(datum1D.data, reimPhaseCorrection(datum1D.data, 0, ph1));
-  }
 }
 
 export function isApplicable(datum1D) {

--- a/src/data/data1d/filter1d/fft.js
+++ b/src/data/data1d/filter1d/fft.js
@@ -1,6 +1,7 @@
 import {
   reimFFT,
   reimFFTShift,
+  xRotate,
   reimPhaseCorrection,
 } from 'ml-spectra-processing';
 
@@ -21,7 +22,7 @@ export function apply(datum1D) {
     (e) => e.name === 'digitalFilter' && e.flag,
   );
 
-  Object.assign(datum1D.data, reimFFTShift(reimFFT(datum1D.data)));
+  Object.assign(datum1D.data, reimFFT(datum1D.data, { applyZeroShift: true }));
 
   if (digitalFilterApplied) {
     let { digitalFilter } = datum1D.info;

--- a/src/data/data1d/filter1d/fft.js
+++ b/src/data/data1d/filter1d/fft.js
@@ -1,7 +1,4 @@
-import {
-  reimFFT,
-  reimPhaseCorrection,
-} from 'ml-spectra-processing';
+import { reimFFT, reimPhaseCorrection } from 'ml-spectra-processing';
 
 export const id = 'fft';
 export const name = 'FFT';

--- a/src/data/data1d/filter1d/fft.js
+++ b/src/data/data1d/filter1d/fft.js
@@ -1,7 +1,5 @@
 import {
   reimFFT,
-  reimFFTShift,
-  xRotate,
   reimPhaseCorrection,
 } from 'ml-spectra-processing';
 


### PR DESCRIPTION
In this pull request there are mainly those changes:
- calling nmr-processing for automatic peaks and ranges picking (so, we need first publish this),

- changed default options for automatic ranges picking avoiding big wrong ranges,

- reduced code for  FFT and added phase correction of residual angle [grpdelay - Int(grpdelay)] if the digital filter is applied

- added noiseFactor option to automatic peak picking option panel 

Resolves #429  resolves #437  resolves #256 resolves #214