### PR TITLE
fix(autoRanges): avoid throw error when diaID does not exist

### DIFF
--- a/src/component/1d/Range.jsx
+++ b/src/component/1d/Range.jsx
@@ -48,17 +48,16 @@ const stylesHighlighted = css`
 
 const Range = ({ rangeData }) => {
   const { id, from, to, integral, kind } = rangeData;
-
   const highlightIDs = useMemo(() => {
     return [].concat(
       [rangeData.id],
       rangeData.diaID ? rangeData.diaID : [],
       rangeData.signal
-        ? rangeData.signal.map((_signal) => _signal.diaID).flat()
+        ? rangeData.signal.map((_signal) => _signal.diaID || []).flat()
         : [],
     );
   }, [rangeData]);
-
+  
   const highlight = useHighlight(highlightIDs);
 
   const { scaleX } = useScale();

--- a/src/component/header/RangesPickingOptionPanel.jsx
+++ b/src/component/header/RangesPickingOptionPanel.jsx
@@ -46,7 +46,7 @@ const RangesPickingOptionPanel = () => {
         peakPicking: {
           minMaxRatio: 0.05,
           nH: 100,
-          compile: false,
+          compile: true,
           frequencyCluster: 16,
           clean: true,
           keepPeaks: true,

--- a/src/component/panels/RangesPanel/RangesTableRow.jsx
+++ b/src/component/panels/RangesPanel/RangesTableRow.jsx
@@ -36,7 +36,7 @@ const RangesTableRow = ({
     return [].concat(
       [rowData.id],
       rowData.diaID ? rowData.diaID : [],
-      rowData.signal ? rowData.signal.map((signal) => signal.diaID).flat() : [],
+      rowData.signal ? rowData.signal.map((signal) => signal.diaID || []).flat() : [],
     );
   }, [rowData]);
 

--- a/src/data/data1d/Datum1D.js
+++ b/src/data/data1d/Datum1D.js
@@ -271,14 +271,14 @@ export class Datum1D {
     const ranges = autoRangesDetection(this, options);
     this.ranges.values = ranges.map((range) => {
       return {
+        diaID: [],
         ...range,
         id: generateID(),
-        diaID: [],
         pubIntegral: 0,
         absolute: this.getIntegration(range.from, range.to),
         kind: 'signal',
         signal: range.signal.map((_signal) => {
-          return { ..._signal, diaID: [] };
+          return { diaID: [], ..._signal };
         }),
       };
     });


### PR DESCRIPTION
The error comes from highlight functionality when diaID does not exist, we should not assign an empty array to diaID because we could include ranges assigned in the future.

